### PR TITLE
Add sensitive setting

### DIFF
--- a/etc/CHANGELOG.md
+++ b/etc/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Replace `protolude` in favor of `rio`
 * Update `parseConfigSpec` to no longer attempt to parse JSON when `yaml` cabal
    flag is set
+* Add `sensitive` setting to `etc/spec` entries
+* Add `Value` type to deal with sensitive values
+* Update examples with `sensitive` values
 
 0.2.0.0
 ----

--- a/etc/src/System/Etc.hs
+++ b/etc/src/System/Etc.hs
@@ -63,7 +63,7 @@ module System.Etc (
 
 import System.Etc.Internal.Resolver.Default (resolveDefault)
 import System.Etc.Internal.Types
-    (Config, ConfigSource (..), ConfigValue, IConfig (..), Value(..))
+    (Config, ConfigSource (..), ConfigValue, IConfig (..), Value (..))
 import System.Etc.Spec
     (ConfigSpec, ConfigurationError (..), parseConfigSpec, readConfigSpec)
 

--- a/etc/src/System/Etc.hs
+++ b/etc/src/System/Etc.hs
@@ -11,6 +11,7 @@ module System.Etc (
   -- $config
     Config
   , IConfig
+  , Value(..)
   , getConfigValue
   , getConfigValueWith
   , getSelectedConfigSource
@@ -62,7 +63,7 @@ module System.Etc (
 
 import System.Etc.Internal.Resolver.Default (resolveDefault)
 import System.Etc.Internal.Types
-    (Config, ConfigSource (..), ConfigValue, IConfig (..))
+    (Config, ConfigSource (..), ConfigValue, IConfig (..), Value(..))
 import System.Etc.Spec
     (ConfigSpec, ConfigurationError (..), parseConfigSpec, readConfigSpec)
 

--- a/etc/src/System/Etc/Internal/Config.hs
+++ b/etc/src/System/Etc/Internal/Config.hs
@@ -22,7 +22,7 @@ configValueToJsonObject configValue = case configValue of
   ConfigValue sources -> case Set.maxView sources of
     Nothing          -> error "this should not happen"
 
-    Just (source, _) -> value source
+    Just (source, _) -> fromValue $ value source
 
   SubConfig configm ->
     configm
@@ -42,7 +42,7 @@ _getConfigValueWith parser keys0 (Config configValue0) =
 
           Just (None  , _) -> throwM $ InvalidConfigKeyPath keys0
 
-          Just (source, _) -> case JSON.iparse parser (value source) of
+          Just (source, _) -> case JSON.iparse parser (fromValue $ value source) of
             JSON.IError path err ->
               JSON.formatError path err & Text.pack & InvalidConfiguration & throwM
 

--- a/etc/src/System/Etc/Internal/Extra/EnvMisspell.hs
+++ b/etc/src/System/Etc/Internal/Extra/EnvMisspell.hs
@@ -35,8 +35,7 @@ lookupSpecEnvKeys spec =
   let foldEnvSettings val acc = case val of
         ConfigValue _defVal _sensitive sources ->
           maybe acc (`Vector.cons` acc) (envVar sources)
-        SubConfig hsh         ->
-          HashMap.foldr foldEnvSettings acc hsh
+        SubConfig hsh -> HashMap.foldr foldEnvSettings acc hsh
   in  foldEnvSettings (SubConfig $ specConfigValues spec) Vector.empty
 
 {-|

--- a/etc/src/System/Etc/Internal/Extra/EnvMisspell.hs
+++ b/etc/src/System/Etc/Internal/Extra/EnvMisspell.hs
@@ -33,8 +33,10 @@ data EnvMisspell
 lookupSpecEnvKeys :: ConfigSpec a -> Vector Text
 lookupSpecEnvKeys spec =
   let foldEnvSettings val acc = case val of
-        ConfigValue _ sources -> maybe acc (`Vector.cons` acc) (envVar sources)
-        SubConfig hsh         -> HashMap.foldr foldEnvSettings acc hsh
+        ConfigValue _defVal _sensitive sources ->
+          maybe acc (`Vector.cons` acc) (envVar sources)
+        SubConfig hsh         ->
+          HashMap.foldr foldEnvSettings acc hsh
   in  foldEnvSettings (SubConfig $ specConfigValues spec) Vector.empty
 
 {-|

--- a/etc/src/System/Etc/Internal/Extra/Printer.hs
+++ b/etc/src/System/Etc/Internal/Extra/Printer.hs
@@ -19,15 +19,16 @@ import Text.PrettyPrint.ANSI.Leijen
 
 import System.Etc.Internal.Types
 
-renderJsonValue :: (Value JSON.Value) -> (Doc, Int)
+renderJsonValue :: Value JSON.Value -> (Doc, Int)
 renderJsonValue value' = case value' of
-  Plain JSON.Null              -> (text "null", 4)
+  Plain JSON.Null         -> (text "null", 4)
 
-  Plain (JSON.String str)        -> (text $ Text.unpack str, Text.length str)
+  Plain (JSON.String str) -> (text $ Text.unpack str, Text.length str)
 
-  Plain (JSON.Number scientific) -> let number = show scientific in (text number, length number)
-  Plain (JSON.Bool   bool')      -> if bool' then (text "true", 5) else (text "false", 5)
-  Sensitive _                    -> (text "<<sensitive>>", 13)
+  Plain (JSON.Number scientific) ->
+    let number = show scientific in (text number, length number)
+  Plain     (JSON.Bool bool') -> if bool' then (text "true", 5) else (text "false", 5)
+  Sensitive _                 -> (text "<<sensitive>>", 13)
   _ ->
     value'
       & tshow

--- a/etc/src/System/Etc/Internal/Extra/Printer.hs
+++ b/etc/src/System/Etc/Internal/Extra/Printer.hs
@@ -19,14 +19,15 @@ import Text.PrettyPrint.ANSI.Leijen
 
 import System.Etc.Internal.Types
 
-renderJsonValue :: JSON.Value -> (Doc, Int)
+renderJsonValue :: (Value JSON.Value) -> (Doc, Int)
 renderJsonValue value' = case value' of
-  JSON.Null              -> (text "null", 4)
+  Plain JSON.Null              -> (text "null", 4)
 
-  JSON.String str        -> (text $ Text.unpack str, Text.length str)
+  Plain (JSON.String str)        -> (text $ Text.unpack str, Text.length str)
 
-  JSON.Number scientific -> let number = show scientific in (text number, length number)
-  JSON.Bool   bool'      -> if bool' then (text "true", 5) else (text "false", 5)
+  Plain (JSON.Number scientific) -> let number = show scientific in (text number, length number)
+  Plain (JSON.Bool   bool')      -> if bool' then (text "true", 5) else (text "false", 5)
+  Sensitive _                    -> (text "<<sensitive>>", 13)
   _ ->
     value'
       & tshow

--- a/etc/src/System/Etc/Internal/Resolver/Cli/Command.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Cli/Command.hs
@@ -111,7 +111,8 @@ specToConfigValueCli
   -> (Text, Spec.ConfigValue cmd)
   -> m (HashMap cmd (Opt.Parser ConfigValue))
 specToConfigValueCli acc (specEntryKey, specConfigValue) = case specConfigValue of
-  Spec.ConfigValue _ sensitive sources   -> configValueSpecToCli acc specEntryKey sensitive sources
+  Spec.ConfigValue _ sensitive sources ->
+    configValueSpecToCli acc specEntryKey sensitive sources
 
   Spec.SubConfig subConfigSpec -> subConfigSpecToCli specEntryKey subConfigSpec acc
 

--- a/etc/src/System/Etc/Internal/Resolver/Cli/Command.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Cli/Command.hs
@@ -22,11 +22,12 @@ import qualified System.Etc.Internal.Spec.Types as Spec
 
 entrySpecToJsonCli
   :: (MonadThrow m)
-  => Spec.CliEntrySpec cmd
-  -> m (Vector cmd, Opt.Parser (Maybe JSON.Value))
-entrySpecToJsonCli entrySpec = case entrySpec of
+  => Bool
+  -> Spec.CliEntrySpec cmd
+  -> m (Vector cmd, Opt.Parser (Maybe (Value JSON.Value)))
+entrySpecToJsonCli sensitive entrySpec = case entrySpec of
   Spec.CmdEntry commandJsonValue specSettings ->
-    return (commandJsonValue, settingsToJsonCli specSettings)
+    return (commandJsonValue, settingsToJsonCli sensitive specSettings)
 
   Spec.PlainEntry{} -> throwM CommandKeyMissing
 
@@ -34,9 +35,10 @@ configValueSpecToCli
   :: (MonadThrow m, Eq cmd, Hashable cmd)
   => HashMap cmd (Opt.Parser ConfigValue)
   -> Text
+  -> Bool
   -> Spec.ConfigSources cmd
   -> m (HashMap cmd (Opt.Parser ConfigValue))
-configValueSpecToCli acc0 specEntryKey sources =
+configValueSpecToCli acc0 specEntryKey sensitive sources =
   let updateAccConfigOptParser configValueParser accOptParser =
         (\configValue accSubConfig -> case accSubConfig of
             ConfigValue{} -> accSubConfig
@@ -50,7 +52,7 @@ configValueSpecToCli acc0 specEntryKey sources =
         Nothing        -> return acc0
 
         Just entrySpec -> do
-          (commands, jsonOptParser) <- entrySpecToJsonCli entrySpec
+          (commands, jsonOptParser) <- entrySpecToJsonCli sensitive entrySpec
 
           let configValueParser = jsonToConfigValue <$> jsonOptParser
 
@@ -109,7 +111,7 @@ specToConfigValueCli
   -> (Text, Spec.ConfigValue cmd)
   -> m (HashMap cmd (Opt.Parser ConfigValue))
 specToConfigValueCli acc (specEntryKey, specConfigValue) = case specConfigValue of
-  Spec.ConfigValue _ sources   -> configValueSpecToCli acc specEntryKey sources
+  Spec.ConfigValue _ sensitive sources   -> configValueSpecToCli acc specEntryKey sensitive sources
 
   Spec.SubConfig subConfigSpec -> subConfigSpecToCli specEntryKey subConfigSpec acc
 

--- a/etc/src/System/Etc/Internal/Resolver/Cli/Common.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Cli/Common.hs
@@ -60,17 +60,21 @@ instance Exception CliConfigError
 
 specToCliSwitchFieldMod specSettings =
   maybe Opt.idm (Opt.long . Text.unpack) (Spec.optLong specSettings)
-    `mappend` maybe Opt.idm (Opt.short . Text.head)  (Spec.optShort specSettings)
+    `mappend` maybe Opt.idm (Opt.short . Text.head) (Spec.optShort specSettings)
     `mappend` maybe Opt.idm (Opt.help . Text.unpack) (Spec.optHelp specSettings)
 
-specToCliVarFieldMod specSettings = specToCliSwitchFieldMod specSettings
-  `mappend` maybe Opt.idm (Opt.metavar . Text.unpack) (Spec.optMetavar specSettings)
+specToCliVarFieldMod specSettings =
+  specToCliSwitchFieldMod specSettings `mappend` maybe
+    Opt.idm
+    (Opt.metavar . Text.unpack)
+    (Spec.optMetavar specSettings)
 
 
 commandToKey :: (MonadThrow m, JSON.ToJSON cmd) => cmd -> m [Text]
 commandToKey cmd = case JSON.toJSON cmd of
   JSON.String commandStr -> return [commandStr]
-  JSON.Array  jsonList   -> jsonList & Vector.toList & mapM commandToKey & (concat <$>)
+  JSON.Array jsonList ->
+    jsonList & Vector.toList & mapM commandToKey & (concat <$>)
   _ ->
     cmd
       & JSON.encode
@@ -80,35 +84,43 @@ commandToKey cmd = case JSON.toJSON cmd of
       & InvalidCliCommandKey
       & throwM
 
-settingsToJsonCli :: Spec.CliEntryMetadata -> Opt.Parser (Maybe JSON.Value)
-settingsToJsonCli specSettings =
+settingsToJsonCli :: Bool -> Spec.CliEntryMetadata -> Opt.Parser (Maybe (Value JSON.Value))
+settingsToJsonCli sensitive specSettings =
   let requiredCombinator =
         if Spec.optRequired specSettings then (Just <$>) else Opt.optional
-  in
-    requiredCombinator $ case specSettings of
-      Spec.Opt{} -> case Spec.optValueType specSettings of
-        Spec.StringOpt ->
-          (JSON.String . Text.pack) <$> Opt.strOption (specToCliVarFieldMod specSettings)
 
-        Spec.NumberOpt -> (JSON.Number . fromInteger)
-          <$> Opt.option Opt.auto (specToCliVarFieldMod specSettings)
+  in  requiredCombinator $ case specSettings of
+        Spec.Opt{} -> case Spec.optValueType specSettings of
+          Spec.StringOpt -> (boolToValue sensitive . JSON.String . Text.pack)
+            <$> Opt.strOption (specToCliVarFieldMod specSettings)
 
-        Spec.SwitchOpt -> JSON.Bool <$> Opt.switch (specToCliSwitchFieldMod specSettings)
+          Spec.NumberOpt -> (boolToValue sensitive . JSON.Number . fromInteger)
+            <$> Opt.option Opt.auto (specToCliVarFieldMod specSettings)
 
-      Spec.Arg{} -> case Spec.argValueType specSettings of
-        Spec.StringArg -> (JSON.String . Text.pack) <$> Opt.strArgument
-          (specSettings & Spec.argMetavar & maybe Opt.idm (Opt.metavar . Text.unpack))
-        Spec.NumberArg -> (JSON.Number . fromInteger) <$> Opt.argument
-          Opt.auto
-          (specSettings & Spec.argMetavar & maybe Opt.idm (Opt.metavar . Text.unpack))
+          Spec.SwitchOpt ->
+            (boolToValue sensitive . JSON.Bool) <$> Opt.switch (specToCliSwitchFieldMod specSettings)
+
+        Spec.Arg{} -> case Spec.argValueType specSettings of
+          Spec.StringArg -> (boolToValue sensitive . JSON.String . Text.pack) <$> Opt.strArgument
+            (specSettings & Spec.argMetavar & maybe
+              Opt.idm
+              (Opt.metavar . Text.unpack)
+            )
+          Spec.NumberArg -> (boolToValue sensitive . JSON.Number . fromInteger) <$> Opt.argument
+            Opt.auto
+            (specSettings & Spec.argMetavar & maybe
+              Opt.idm
+              (Opt.metavar . Text.unpack)
+            )
 
 parseCommandJsonValue :: (MonadThrow m, JSON.FromJSON a) => JSON.Value -> m a
-parseCommandJsonValue commandValue = case JSON.iparse JSON.parseJSON commandValue of
-  JSON.IError _path err -> throwM (InvalidCliCommandKey $ Text.pack err)
+parseCommandJsonValue commandValue =
+  case JSON.iparse JSON.parseJSON commandValue of
+    JSON.IError _path err -> throwM (InvalidCliCommandKey $ Text.pack err)
 
-  JSON.ISuccess result  -> return result
+    JSON.ISuccess result  -> return result
 
-jsonToConfigValue :: Maybe JSON.Value -> ConfigValue
+jsonToConfigValue :: Maybe (Value JSON.Value) -> ConfigValue
 jsonToConfigValue specEntryDefVal =
   ConfigValue $ Set.fromList $ maybe [] ((: []) . Cli) specEntryDefVal
 
@@ -127,13 +139,17 @@ handleCliResult result = case result of
 
     _ -> throwIO err
 
-programResultToResolverResult :: MonadThrow m => Text -> Opt.ParserResult a -> m a
+programResultToResolverResult
+  :: MonadThrow m => Text -> Opt.ParserResult a -> m a
 programResultToResolverResult progName programResult = case programResult of
   Opt.Success result -> return result
 
   Opt.Failure failure ->
-    let (outputMsg, exitCode) = Opt.renderFailure failure $ Text.unpack progName
-    in  throwM $ CliEvalExited exitCode (GetErrorMessage $ return (Text.pack outputMsg))
+    let (outputMsg, exitCode) =
+          Opt.renderFailure failure $ Text.unpack progName
+    in  throwM $ CliEvalExited
+          exitCode
+          (GetErrorMessage $ return (Text.pack outputMsg))
 
   Opt.CompletionInvoked compl ->
     let getMsg = Text.pack <$> Opt.execCompletion compl (Text.unpack progName)

--- a/etc/src/System/Etc/Internal/Resolver/Cli/Common.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Cli/Common.hs
@@ -60,21 +60,17 @@ instance Exception CliConfigError
 
 specToCliSwitchFieldMod specSettings =
   maybe Opt.idm (Opt.long . Text.unpack) (Spec.optLong specSettings)
-    `mappend` maybe Opt.idm (Opt.short . Text.head) (Spec.optShort specSettings)
+    `mappend` maybe Opt.idm (Opt.short . Text.head)  (Spec.optShort specSettings)
     `mappend` maybe Opt.idm (Opt.help . Text.unpack) (Spec.optHelp specSettings)
 
-specToCliVarFieldMod specSettings =
-  specToCliSwitchFieldMod specSettings `mappend` maybe
-    Opt.idm
-    (Opt.metavar . Text.unpack)
-    (Spec.optMetavar specSettings)
+specToCliVarFieldMod specSettings = specToCliSwitchFieldMod specSettings
+  `mappend` maybe Opt.idm (Opt.metavar . Text.unpack) (Spec.optMetavar specSettings)
 
 
 commandToKey :: (MonadThrow m, JSON.ToJSON cmd) => cmd -> m [Text]
 commandToKey cmd = case JSON.toJSON cmd of
   JSON.String commandStr -> return [commandStr]
-  JSON.Array jsonList ->
-    jsonList & Vector.toList & mapM commandToKey & (concat <$>)
+  JSON.Array  jsonList   -> jsonList & Vector.toList & mapM commandToKey & (concat <$>)
   _ ->
     cmd
       & JSON.encode
@@ -88,37 +84,33 @@ settingsToJsonCli :: Bool -> Spec.CliEntryMetadata -> Opt.Parser (Maybe (Value J
 settingsToJsonCli sensitive specSettings =
   let requiredCombinator =
         if Spec.optRequired specSettings then (Just <$>) else Opt.optional
+  in
+    requiredCombinator $ case specSettings of
+      Spec.Opt{} -> case Spec.optValueType specSettings of
+        Spec.StringOpt -> (boolToValue sensitive . JSON.String . Text.pack)
+          <$> Opt.strOption (specToCliVarFieldMod specSettings)
 
-  in  requiredCombinator $ case specSettings of
-        Spec.Opt{} -> case Spec.optValueType specSettings of
-          Spec.StringOpt -> (boolToValue sensitive . JSON.String . Text.pack)
-            <$> Opt.strOption (specToCliVarFieldMod specSettings)
-
-          Spec.NumberOpt -> (boolToValue sensitive . JSON.Number . fromInteger)
+        Spec.NumberOpt ->
+          (boolToValue sensitive . JSON.Number . fromInteger)
             <$> Opt.option Opt.auto (specToCliVarFieldMod specSettings)
 
-          Spec.SwitchOpt ->
-            (boolToValue sensitive . JSON.Bool) <$> Opt.switch (specToCliSwitchFieldMod specSettings)
+        Spec.SwitchOpt -> (boolToValue sensitive . JSON.Bool)
+          <$> Opt.switch (specToCliSwitchFieldMod specSettings)
 
-        Spec.Arg{} -> case Spec.argValueType specSettings of
-          Spec.StringArg -> (boolToValue sensitive . JSON.String . Text.pack) <$> Opt.strArgument
-            (specSettings & Spec.argMetavar & maybe
-              Opt.idm
-              (Opt.metavar . Text.unpack)
-            )
-          Spec.NumberArg -> (boolToValue sensitive . JSON.Number . fromInteger) <$> Opt.argument
+      Spec.Arg{} -> case Spec.argValueType specSettings of
+        Spec.StringArg ->
+          (boolToValue sensitive . JSON.String . Text.pack) <$> Opt.strArgument
+            (specSettings & Spec.argMetavar & maybe Opt.idm (Opt.metavar . Text.unpack))
+        Spec.NumberArg ->
+          (boolToValue sensitive . JSON.Number . fromInteger) <$> Opt.argument
             Opt.auto
-            (specSettings & Spec.argMetavar & maybe
-              Opt.idm
-              (Opt.metavar . Text.unpack)
-            )
+            (specSettings & Spec.argMetavar & maybe Opt.idm (Opt.metavar . Text.unpack))
 
 parseCommandJsonValue :: (MonadThrow m, JSON.FromJSON a) => JSON.Value -> m a
-parseCommandJsonValue commandValue =
-  case JSON.iparse JSON.parseJSON commandValue of
-    JSON.IError _path err -> throwM (InvalidCliCommandKey $ Text.pack err)
+parseCommandJsonValue commandValue = case JSON.iparse JSON.parseJSON commandValue of
+  JSON.IError _path err -> throwM (InvalidCliCommandKey $ Text.pack err)
 
-    JSON.ISuccess result  -> return result
+  JSON.ISuccess result  -> return result
 
 jsonToConfigValue :: Maybe (Value JSON.Value) -> ConfigValue
 jsonToConfigValue specEntryDefVal =
@@ -139,17 +131,13 @@ handleCliResult result = case result of
 
     _ -> throwIO err
 
-programResultToResolverResult
-  :: MonadThrow m => Text -> Opt.ParserResult a -> m a
+programResultToResolverResult :: MonadThrow m => Text -> Opt.ParserResult a -> m a
 programResultToResolverResult progName programResult = case programResult of
   Opt.Success result -> return result
 
   Opt.Failure failure ->
-    let (outputMsg, exitCode) =
-          Opt.renderFailure failure $ Text.unpack progName
-    in  throwM $ CliEvalExited
-          exitCode
-          (GetErrorMessage $ return (Text.pack outputMsg))
+    let (outputMsg, exitCode) = Opt.renderFailure failure $ Text.unpack progName
+    in  throwM $ CliEvalExited exitCode (GetErrorMessage $ return (Text.pack outputMsg))
 
   Opt.CompletionInvoked compl ->
     let getMsg = Text.pack <$> Opt.execCompletion compl (Text.unpack progName)

--- a/etc/src/System/Etc/Internal/Resolver/Default.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Default.hs
@@ -12,7 +12,8 @@ import qualified System.Etc.Internal.Spec.Types as Spec
 import           System.Etc.Internal.Types
 
 toDefaultConfigValue :: Bool -> JSON.Value -> ConfigValue
-toDefaultConfigValue sensitive = ConfigValue . Set.singleton . Default . boolToValue sensitive
+toDefaultConfigValue sensitive =
+  ConfigValue . Set.singleton . Default . boolToValue sensitive
 
 buildDefaultResolver :: Spec.ConfigSpec cmd -> Maybe ConfigValue
 buildDefaultResolver spec =

--- a/etc/src/System/Etc/Internal/Resolver/Default.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Default.hs
@@ -11,16 +11,16 @@ import qualified Data.Aeson as JSON
 import qualified System.Etc.Internal.Spec.Types as Spec
 import           System.Etc.Internal.Types
 
-toDefaultConfigValue :: JSON.Value -> ConfigValue
-toDefaultConfigValue = ConfigValue . Set.singleton . Default
+toDefaultConfigValue :: Bool -> JSON.Value -> ConfigValue
+toDefaultConfigValue sensitive = ConfigValue . Set.singleton . Default . boolToValue sensitive
 
 buildDefaultResolver :: Spec.ConfigSpec cmd -> Maybe ConfigValue
 buildDefaultResolver spec =
   let resolverReducer
         :: Text -> Spec.ConfigValue cmd -> Maybe ConfigValue -> Maybe ConfigValue
       resolverReducer specKey specValue mConfig = case specValue of
-        Spec.ConfigValue def _ ->
-          let mConfigSource = toDefaultConfigValue <$> def
+        Spec.ConfigValue def sensitive _ ->
+          let mConfigSource = toDefaultConfigValue sensitive <$> def
 
               updateConfig  = writeInSubConfig specKey <$> mConfigSource <*> mConfig
           in  updateConfig <|> mConfig

--- a/etc/src/System/Etc/Internal/Resolver/Env.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Env.hs
@@ -14,9 +14,11 @@ import qualified Data.Aeson    as JSON
 import qualified System.Etc.Internal.Spec.Types as Spec
 import           System.Etc.Internal.Types
 
-resolveEnvVarSource :: (Text -> Maybe Text) -> Bool -> Spec.ConfigSources cmd -> Maybe ConfigSource
+resolveEnvVarSource
+  :: (Text -> Maybe Text) -> Bool -> Spec.ConfigSources cmd -> Maybe ConfigSource
 resolveEnvVarSource lookupEnv sensitive specSources =
-  let toEnvSource varname envValue = envValue & JSON.String & boolToValue sensitive & Env varname
+  let toEnvSource varname envValue =
+        envValue & JSON.String & boolToValue sensitive & Env varname
   in  do
         varname <- Spec.envVar specSources
         toEnvSource varname <$> lookupEnv varname

--- a/etc/src/System/Etc/Internal/Resolver/File.hs
+++ b/etc/src/System/Etc/Internal/Resolver/File.hs
@@ -10,7 +10,6 @@ import qualified RIO.Set       as Set
 import qualified RIO.Text      as Text
 import qualified RIO.Vector    as Vector
 
-
 #ifdef WITH_YAML
 import qualified Data.Yaml as YAML
 #endif
@@ -31,17 +30,38 @@ data ConfigFile
 
 --------------------------------------------------------------------------------
 
-parseConfigValue :: Monad m => Int -> Text -> JSON.Value -> m ConfigValue
-parseConfigValue fileIndex filepath json = case json of
+parseConfigValue :: Monad m => Maybe (Spec.ConfigValue cmd) -> Int -> Text -> JSON.Value -> m ConfigValue
+parseConfigValue mSpec fileIndex filepath json = case json of
   JSON.Object object -> SubConfig <$> foldM
-    (\acc (key, subconfigValue) -> do
-      value1 <- parseConfigValue fileIndex filepath subconfigValue
+    (\acc (key, subConfigValue) -> do
+      let
+        msubConfigSpec = do
+          spec <- mSpec
+          case spec of
+            Spec.SubConfig hsh ->
+              HashMap.lookup key hsh
+            _ ->
+              -- TODO: This should be an error given the config doesn't match spec
+              fail "configuration spec and configuration value are different"
+
+      value1 <- parseConfigValue msubConfigSpec fileIndex filepath subConfigValue
       return $ HashMap.insert key value1 acc
     )
     HashMap.empty
     (HashMap.toList object)
 
-  _ -> return $ ConfigValue (Set.singleton $ File fileIndex filepath json)
+  _ ->
+    let
+      mToValue = do
+        spec <- mSpec
+        case spec of
+          Spec.ConfigValue {} -> return $ boolToValue (Spec.isSensitive spec)
+          _ -> fail "configuration spec and configuration value are different"
+
+      toValue =
+        fromMaybe Plain mToValue
+
+    in return $ ConfigValue (Set.singleton $ File fileIndex filepath (toValue json))
 
 
 eitherDecode :: ConfigFile -> Either String JSON.Value
@@ -59,11 +79,11 @@ eitherDecode contents0 = case contents0 of
 #endif
 
 
-parseConfig :: MonadThrow m => Int -> Text -> ConfigFile -> m Config
-parseConfig fileIndex filepath contents = case eitherDecode contents of
+parseConfig :: MonadThrow m => Spec.ConfigValue cmd -> Int -> Text -> ConfigFile -> m Config
+parseConfig spec fileIndex filepath contents = case eitherDecode contents of
   Left  err  -> throwM $ InvalidConfiguration (Text.pack err)
 
-  Right json -> case JSON.iparse (parseConfigValue fileIndex filepath) json of
+  Right json -> case JSON.iparse (parseConfigValue (Just spec) fileIndex filepath) json of
     JSON.IError _ err    -> throwM $ InvalidConfiguration (Text.pack err)
 
     JSON.ISuccess result -> return (Config result)
@@ -86,14 +106,14 @@ readConfigFile filepath =
               else return (throwM $ InvalidConfiguration "Unsupported file extension")
         else return $ throwM $ ConfigurationFileNotFound filepath
 
-readConfigFromFiles :: [Text] -> IO (Config, [SomeException])
-readConfigFromFiles files =
-  files
+readConfigFromFiles :: Spec.ConfigSpec cmd -> IO (Config, [SomeException])
+readConfigFromFiles spec =
+  Spec.specConfigFilepaths spec
     & zip [1 ..]
     & mapM
         (\(fileIndex, filepath) -> do
           mContents <- readConfigFile filepath
-          return (mContents >>= parseConfig fileIndex filepath)
+          return (mContents >>= parseConfig (Spec.SubConfig $ Spec.specConfigValues spec) fileIndex filepath)
         )
     & (foldl'
         (\(result, errs) eCurrent -> case eCurrent of
@@ -115,5 +135,5 @@ resolveFiles
   :: Spec.ConfigSpec cmd -- ^ Config Spec
   -> IO (Config, Vector SomeException) -- ^ Configuration Map with all values from files filled in and a list of warnings
 resolveFiles spec = do
-  (config, exceptions) <- readConfigFromFiles (Spec.specConfigFilepaths spec)
+  (config, exceptions) <- readConfigFromFiles spec
   return (config, Vector.fromList exceptions)

--- a/etc/src/System/Etc/Internal/Spec/Types.hs
+++ b/etc/src/System/Etc/Internal/Spec/Types.hs
@@ -250,7 +250,7 @@ instance JSON.FromJSON cmd => JSON.FromJSON (ConfigValue cmd) where
             fail "etc/spec value must be a JSON object"
 
       _ ->
-        return $
+        return
           ConfigValue
           {
             defaultValue = Just json

--- a/etc/src/System/Etc/Internal/Spec/Types.hs
+++ b/etc/src/System/Etc/Internal/Spec/Types.hs
@@ -78,6 +78,7 @@ data ConfigSources cmd
 data ConfigValue cmd
   = ConfigValue {
     defaultValue  :: !(Maybe JSON.Value)
+  , isSensitive   :: !Bool
   , configSources :: !(ConfigSources cmd)
   }
   | SubConfig {
@@ -232,12 +233,15 @@ instance JSON.FromJSON cmd => JSON.FromJSON (ConfigValue cmd) where
               return (SubConfig result)
 
           -- etc spec value object
-          Just (JSON.Object spec) ->
-            if HashMap.size object == 1 then
+          Just (JSON.Object fieldSpec) ->
+            if HashMap.size object == 1 then do
+              mSensitive <- fieldSpec .:? "sensitive"
+              let sensitive = fromMaybe False mSensitive
               ConfigValue
-                <$> spec .:? "default"
-                <*> (ConfigSources <$> (spec .:? "env")
-                                   <*> (spec .:? "cli"))
+                <$> fieldSpec .:? "default"
+                <*> pure sensitive
+                <*> (ConfigSources <$> fieldSpec .:? "env"
+                                   <*> fieldSpec .:? "cli")
             else
               fail "etc/spec object can only contain one key"
 
@@ -247,7 +251,12 @@ instance JSON.FromJSON cmd => JSON.FromJSON (ConfigValue cmd) where
 
       _ ->
         return $
-          ConfigValue (Just json) (ConfigSources Nothing Nothing)
+          ConfigValue
+          {
+            defaultValue = Just json
+          , isSensitive = False
+          , configSources = ConfigSources Nothing Nothing
+          }
 
 instance JSON.FromJSON cmd => JSON.FromJSON (ConfigSpec cmd) where
   parseJSON json  =

--- a/etc/src/System/Etc/Internal/Types.hs
+++ b/etc/src/System/Etc/Internal/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE RankNTypes                 #-}
@@ -12,7 +12,7 @@ import           RIO
 import qualified RIO.HashMap as HashMap
 import qualified RIO.Set     as Set
 
-import Data.Bool (bool)
+import           Data.Bool      (bool)
 import qualified Data.Semigroup as Semigroup
 
 import qualified Data.Aeson       as JSON
@@ -29,23 +29,23 @@ data Value a
   deriving (Generic, Eq, Ord)
 
 instance Show a => Show (Value a) where
-  show (Plain a) = show a
+  show (Plain a)     = show a
   show (Sensitive _) = "<<sensitive>>"
 
 instance Functor Value where
   fmap f val =
     case val of
-      Plain a -> Plain (f a)
+      Plain a     -> Plain (f a)
       Sensitive a -> Sensitive (f a)
 
 instance Applicative Value where
   pure a = Plain a
   (<*>) vf va =
     case (vf, va) of
-      (Plain f, Plain a) -> Plain (f a)
+      (Plain f, Plain a)         -> Plain (f a)
       (Sensitive f, Sensitive a) -> Sensitive (f a)
-      (Sensitive f, Plain a) -> Sensitive (f a)
-      (Plain f, Sensitive a) -> Sensitive (f a)
+      (Sensitive f, Plain a)     -> Sensitive (f a)
+      (Plain f, Sensitive a)     -> Sensitive (f a)
 
 instance IsString a => IsString (Value a) where
   fromString = Plain . fromString

--- a/etc/src/System/Etc/Internal/Types.hs
+++ b/etc/src/System/Etc/Internal/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE RankNTypes                 #-}
@@ -11,6 +12,7 @@ import           RIO
 import qualified RIO.HashMap as HashMap
 import qualified RIO.Set     as Set
 
+import Data.Bool (bool)
 import qualified Data.Semigroup as Semigroup
 
 import qualified Data.Aeson       as JSON
@@ -21,21 +23,51 @@ import System.Etc.Internal.Spec.Types (ConfigurationError (..))
 --------------------
 -- Configuration Types
 
+data Value a
+  = Plain { fromValue :: !a }
+  | Sensitive { fromValue :: !a }
+  deriving (Generic, Eq, Ord)
+
+instance Show a => Show (Value a) where
+  show (Plain a) = show a
+  show (Sensitive _) = "<<sensitive>>"
+
+instance Functor Value where
+  fmap f val =
+    case val of
+      Plain a -> Plain (f a)
+      Sensitive a -> Sensitive (f a)
+
+instance Applicative Value where
+  pure a = Plain a
+  (<*>) vf va =
+    case (vf, va) of
+      (Plain f, Plain a) -> Plain (f a)
+      (Sensitive f, Sensitive a) -> Sensitive (f a)
+      (Sensitive f, Plain a) -> Sensitive (f a)
+      (Plain f, Sensitive a) -> Sensitive (f a)
+
+instance IsString a => IsString (Value a) where
+  fromString = Plain . fromString
+
+boolToValue :: Bool -> (a -> Value a)
+boolToValue = bool Plain Sensitive
+
 data ConfigSource
   = File {
-      configIndex :: Int
-    , filepath    :: Text
-    , value       :: JSON.Value
+      configIndex :: !Int
+    , filepath    :: !Text
+    , value       :: !(Value JSON.Value)
     }
   | Env {
-      envVar :: Text
-    , value  :: JSON.Value
+      envVar :: !Text
+    , value  :: !(Value JSON.Value)
     }
   | Cli {
-      value :: JSON.Value
+      value :: !(Value JSON.Value)
     }
   | Default {
-      value :: JSON.Value
+      value :: !(Value JSON.Value)
     }
   | None
   deriving (Show, Eq)
@@ -75,10 +107,10 @@ instance Ord ConfigSource where
 
 data ConfigValue
   = ConfigValue {
-      configSource :: Set ConfigSource
+      configSource :: !(Set ConfigSource)
     }
   | SubConfig {
-      configMap :: HashMap Text ConfigValue
+      configMap :: !(HashMap Text ConfigValue)
     }
   deriving (Eq, Show)
 

--- a/etc/test/System/Etc/Resolver/DefaultTest.hs
+++ b/etc/test/System/Etc/Resolver/DefaultTest.hs
@@ -49,5 +49,5 @@ tests = testGroup
     case getAllConfigSources ["greeting"] config of
       Nothing   -> assertFailure ("expecting to get entries for greeting\n" <> show config)
       Just aSet -> assertBool ("expecting to see entry from env; got " <> show aSet)
-                              (Set.member (Default JSON.Null) aSet)
+                              (Set.member (Default $ Plain JSON.Null) aSet)
   ]

--- a/examples/etc-command-example/resources/spec.yaml
+++ b/examples/etc-command-example/resources/spec.yaml
@@ -30,6 +30,7 @@ etc/entries:
           - run
     password:
       etc/spec:
+        sensitive: true
         env: "MY_APP_PASSWORD"
         cli:
           input: "option"

--- a/examples/etc-embedded-config-example/resources/spec.yaml
+++ b/examples/etc-embedded-config-example/resources/spec.yaml
@@ -21,6 +21,7 @@ etc/entries:
           required: false
     password:
       etc/spec:
+        sensitive: true
         env: "MY_APP_PASSWORD"
         cli:
           input: "option"

--- a/examples/etc-plain-example/resources/spec.yaml
+++ b/examples/etc-plain-example/resources/spec.yaml
@@ -21,6 +21,7 @@ etc/entries:
           required: false
     password:
       etc/spec:
+        sensitive: true
         env: "MY_APP_PASSWORD"
         cli:
           input: "option"


### PR DESCRIPTION
h3. Context

Some configuration values should never be shown when displaying the configuration map, this PR adds a new type `Value` that wraps configuration values into a sensitive context, this way we can avoid leaking secrets through debugging tools