### PR TITLE
[32] Print Array Config Value

### DIFF
--- a/etc/CHANGELOG.md
+++ b/etc/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.4.0.1
+----
+
+* Improve pretty printer for configuration values (closes #32)
+
 0.4.0.0
 ----
 **BREAKING CHANGES**

--- a/etc/src/System/Etc/Internal/Spec/Types.hs
+++ b/etc/src/System/Etc/Internal/Spec/Types.hs
@@ -244,7 +244,7 @@ inferErrorMsg :: String
 inferErrorMsg = "could not infer type from given default value"
 
 parseBytesToConfigValueJSON :: ConfigValueType -> Text -> Maybe JSON.Value
-parseBytesToConfigValueJSON cvType content = do
+parseBytesToConfigValueJSON cvType content =
   case JSON.eitherDecodeStrict' (Text.encodeUtf8 content) of
     Right value | matchesConfigValueType value cvType -> return value
                 | otherwise                           -> Nothing
@@ -260,7 +260,7 @@ jsonToConfigValueType json = case json of
   JSON.Array arr
     | null arr -> Left inferErrorMsg
     | otherwise -> case jsonToConfigValueType (Vector.head arr) of
-      Right (CVTArray{}  ) -> Left "nested arrays values are not supported"
+      Right CVTArray{}     -> Left "nested arrays values are not supported"
       Right (CVTSingle ty) -> Right $ CVTArray ty
       Left  err            -> Left err
   _ -> Left inferErrorMsg
@@ -319,7 +319,7 @@ instance JSON.FromJSON cmd => JSON.FromJSON (ConfigValue cmd) where
             if HashMap.size object == 1 then do
               -- NOTE: not using .:? here as it casts JSON.Null to Nothing, we
               -- want (Just JSON.Null) returned
-              mDefaultValue <- pure $ maybe Nothing Just $ HashMap.lookup "default" fieldSpec
+              let mDefaultValue = maybe Nothing Just $ HashMap.lookup "default" fieldSpec
               mSensitive    <- fieldSpec .:? "sensitive"
               mCvType       <- fieldSpec .:? "type"
               let sensitive = fromMaybe False mSensitive

--- a/etc/test/System/Etc/Resolver/Cli/PlainTest.hs
+++ b/etc/test/System/Etc/Resolver/Cli/PlainTest.hs
@@ -31,7 +31,7 @@ resolver_tests = testGroup
       eConfig <- try $ SUT.resolvePlainCliPure spec "program" ["-g", "hello world"]
 
       case eConfig of
-        Left (SUT.CliEvalExited{}) -> assertBool "" True
+        Left SUT.CliEvalExited{} -> assertBool "" True
         _ ->
           assertFailure $ "Expecting CliEvalExited error; got this instead " <> show eConfig
   ]

--- a/etc/test/System/Etc/SpecTest.hs
+++ b/etc/test/System/Etc/SpecTest.hs
@@ -52,7 +52,7 @@ general_tests = testGroup
 
     case parseConfigSpec input of
       Left err -> case fromException err of
-        Just (InvalidConfiguration{}) -> assertBool "" True
+        Just InvalidConfiguration{} -> assertBool "" True
 
         _ ->
           assertFailure
@@ -103,7 +103,7 @@ general_tests = testGroup
     let input = "{\"etc/entries\":{\"greeting\": []}}"
     case parseConfigSpec input of
       Left err -> case fromException err of
-        Just (InvalidConfiguration{}) -> assertBool "" True
+        Just InvalidConfiguration{} -> assertBool "" True
         _ ->
           assertFailure $ "expecting InvalidConfiguration error; got instead " <> show err
 

--- a/make/tools.make
+++ b/make/tools.make
@@ -1,7 +1,7 @@
 # -*- mode: Makefile; -*-
 ################################################################################
 
-TOOLS_DIR ?= ./tools/bin
+TOOLS_DIR ?= $$(pwd)/tools/bin
 
 BRITTANY_BIN := $(TOOLS_DIR)/brittany
 STYLISH_BIN := $(TOOLS_DIR)/stylish-haskell


### PR DESCRIPTION
Currently, we do not support the ability to pretty print config values that are arrays inside objects.

This ticket accommodates printing strategies for complex data structures in configuration values 