### PR TITLE
Make sure non-existing inputs from CLI are reported as cast errors

### DIFF
--- a/etc/src/System/Etc/Internal/Config.hs
+++ b/etc/src/System/Etc/Internal/Config.hs
@@ -20,7 +20,7 @@ import System.Etc.Internal.Types
 configValueToJsonObject :: ConfigValue -> JSON.Value
 configValueToJsonObject configValue = case configValue of
   ConfigValue sources -> case Set.maxView sources of
-    Nothing          -> error "this should not happen"
+    Nothing          -> JSON.Null
 
     Just (source, _) -> fromValue $ value source
 

--- a/etc/src/System/Etc/Internal/Extra/Printer.hs
+++ b/etc/src/System/Etc/Internal/Extra/Printer.hs
@@ -164,7 +164,7 @@ renderConfig_ ColorFn { blueColor } (Config configMap) =
               --   - Value 2
               --   - Value 3
               --
-              return $ sourceDoc <$$> (indent 2 $ align (vsep multipleValues))
+              return $ sourceDoc <$$> indent 2 (align (vsep multipleValues))
       in  case eSourceDocs of
             Left  err -> throwM $ InvalidConfiguration (Just keyPath) err
 
@@ -207,7 +207,7 @@ renderConfig_ ColorFn { blueColor } (Config configMap) =
   in
     do
       result <- loop [] configMap
-      return $ (hcat $ intersperse (linebreak <> linebreak) $ result) <> linebreak
+      return $ hcat (intersperse (linebreak <> linebreak) result) <> linebreak
 
 
 renderConfigColor :: MonadThrow m => Config -> m Doc

--- a/etc/src/System/Etc/Internal/Resolver/Env.hs
+++ b/etc/src/System/Etc/Internal/Resolver/Env.hs
@@ -20,7 +20,7 @@ resolveEnvVarSource
   -> Spec.ConfigSources cmd
   -> Maybe ConfigSource
 resolveEnvVarSource lookupEnv configValueType isSensitive specSources =
-  let envTextToJSON envValue = Spec.parseBytesToConfigValueJSON configValueType envValue
+  let envTextToJSON = Spec.parseBytesToConfigValueJSON configValueType
 
       toEnvSource varname envValue =
         Env varname . markAsSensitive isSensitive <$> envTextToJSON envValue

--- a/etc/src/System/Etc/Internal/Spec/Types.hs
+++ b/etc/src/System/Etc/Internal/Spec/Types.hs
@@ -273,7 +273,7 @@ matchesConfigValueType json cvType = case (json, cvType) of
   (JSON.Bool{}  , CVTSingle CVTBool  ) -> True
   (JSON.Object{}, CVTSingle CVTObject) -> True
   (JSON.Array arr, CVTArray inner) ->
-    if null arr then True else all (flip matchesConfigValueType (CVTSingle inner)) arr
+    if null arr then True else all (`matchesConfigValueType` (CVTSingle inner)) arr
   _ -> False
 
 assertMatchingConfigValueType :: Monad m => JSON.Value -> ConfigValueType -> m ()


### PR DESCRIPTION
### Context

When having CLI arguments that: 

* are not required
* don't have default values
* don't have any other source

The program fails with an `error` call, it should instead, return an Aeson `Null` value and let the casting algorithm report the error correctly.